### PR TITLE
Use compiler's devServer config, w/ a fallback

### DIFF
--- a/plugins/webpack/hmr/HmrClient.mjs
+++ b/plugins/webpack/hmr/HmrClient.mjs
@@ -56,7 +56,7 @@ export const browserDevServerConfig = () =>
 			progress: getHook(browserDevServerClientProgressSymbol, true),
 		},
 		devMiddleware: {
-			publicPath: getHmrClientPublicUrl().href,
+			publicPath: getHmrClientPublicUrl().pathname,
 		},
 		static: {
 			watch: getHook(browserDevServerWatchSymbol, {

--- a/plugins/webpack/webpack-plugins/BrowserDevServer.mjs
+++ b/plugins/webpack/webpack-plugins/BrowserDevServer.mjs
@@ -47,8 +47,8 @@ export default class BrowserDevServerPlugin {
 				}
 			});
 			waitForCleanup.then(async () => {
-				// todo: get this from the compilation's devServer config somehow instead
-				const options = browserDevServerConfig();
+				// Use compiler's devServer so preCompile hooks (e.g. writeToDisk, static dir) are applied
+				const options = compiler.options.devServer ?? browserDevServerConfig();
 
 				// WebpackDevServer API docs: https://webpack.js.org/api/webpack-dev-server/
 				const clientDevServer = (this.clientDevServer = new WebpackDevServer(

--- a/plugins/webpack/webpack-plugins/BrowserDevServer.mjs
+++ b/plugins/webpack/webpack-plugins/BrowserDevServer.mjs
@@ -59,6 +59,18 @@ export default class BrowserDevServerPlugin {
 				try {
 					await clientDevServer.start();
 
+					// wdm (webpack-dev-middleware) replaces compiler.outputFileSystem with a
+					// fresh memfs during start(). webpack's emit tracking (_assetEmittingWrittenFiles,
+					// _assetEmittingPreviousFiles, _assetEmittingSourceCache) is populated from the
+					// preceding run() build and refers to the old (real) FS. Without resetting it,
+					// webpack's next watch compilation skips re-emitting unchanged chunks because it
+					// thinks they're already written — leaving them absent from the new memfs and
+					// causing 404s for any lazy-loaded chunk that didn't change between run() and
+					// the first watch build.
+					compiler._assetEmittingWrittenFiles = new Map();
+					compiler._assetEmittingPreviousFiles = new Set();
+					compiler._assetEmittingSourceCache = new WeakMap();
+
 					// without this initial invalidation, HMR doesn't start until you make
 					// a code edit. /static/js/client.js will be missing the
 					// webpack/hot/dev-server.js require.


### PR DESCRIPTION
## Problem

In dev mode, lazy-loaded chunks (e.g. `topbar.chunk.js`) returned 404 from the webpack-dev-server, crashing the app on load. `client.js` served correctly but any dynamic `import()` chunk failed.

## Root cause

The build pipeline runs a one-shot `webpack().run()` to produce the initial build, writing all assets to the real filesystem. `BrowserDevServerPlugin` then starts webpack-dev-server (WDS) via `afterDone`. WDS's internal webpack-dev-middleware (wdm) replaces `compiler.outputFileSystem` with a fresh in-memory filesystem (memfs) and starts a watch compilation.

webpack tracks emitted assets across compilations on the `Compiler` instance via three maps: `_assetEmittingWrittenFiles`, `_assetEmittingPreviousFiles`, and `_assetEmittingSourceCache`. These are populated by the `run()` build and refer to the old real FS. When the subsequent watch compilation emits, webpack sees unchanged chunks in its tracking maps, assumes they're already on disk, and **skips writing them to the new memfs**. Changed files like `client.js` (modified by WDS's HMR plugin injection) get written; everything else does not.

## Fix

Reset the three emit tracking structures on the compiler immediately after `clientDevServer.start()` — at the point when wdm has already swapped the `outputFileSystem`. This causes webpack to treat the new memfs as a blank slate and write all assets unconditionally on the first watch compilation.

Also corrects `devMiddleware.publicPath` from `.href` (full absolute URL) to `.pathname` so wdm's URL-to-path matching is unambiguous.